### PR TITLE
feat: add support for sorting combos by the date they were added

### DIFF
--- a/lib/api/parse-query/parse-sort.ts
+++ b/lib/api/parse-query/parse-sort.ts
@@ -35,7 +35,7 @@ export default function parseSort(
     case "steps":
     case "results":
     case "cards":
-    case "id":
+    case "created":
       // make no changes to value
       break;
     case "ci":

--- a/lib/api/sort-combos.ts
+++ b/lib/api/sort-combos.ts
@@ -25,7 +25,7 @@ const ORDER_DEFAULTS: Record<SortValue, OrderValue> = {
   results: "ascending",
   cards: "ascending",
   colors: "ascending",
-  id: "ascending",
+  created: "ascending",
 
   popularity: "descending",
   price: "descending",
@@ -122,11 +122,13 @@ export default function sortCombos(
     };
 
     switch (by) {
-      case "id":
+      case "created":
         meta.isEqual =
-          firstCombo.commanderSpellbookId === secondCombo.commanderSpellbookId;
+          Number(firstCombo.commanderSpellbookId) ===
+          Number(secondCombo.commanderSpellbookId);
         meta.firstRemainsFirst =
-          firstCombo.commanderSpellbookId > secondCombo.commanderSpellbookId;
+          Number(firstCombo.commanderSpellbookId) >
+          Number(secondCombo.commanderSpellbookId);
         break;
       case "cards":
       case "prerequisites":

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -48,7 +48,7 @@ export type SortValue =
   | "results"
   | "cards"
   | "colors"
-  | "id"
+  | "created"
   | "price"
   | "popularity";
 export type OrderValue = "auto" | "ascending" | "descending";

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -182,6 +182,10 @@ export default Vue.extend({
           value: "results",
           label: "# of Results",
         },
+        {
+          value: "created",
+          label: "Date Added to Site",
+        },
       ];
     },
 

--- a/pages/syntax-guide.vue
+++ b/pages/syntax-guide.vue
@@ -354,6 +354,8 @@
         </li>
 
         <li><code>cards</code> (or <code>number-of-cards</code>)</li>
+
+        <li><code>created</code></li>
       </ul>
 
       <p>
@@ -598,9 +600,9 @@ export default Vue.extend({
             "Combos with fewer than 3 steps sorted by color identity, starting with the most colors and going to the fewest.",
         },
         {
-          search: "decks>100 sort:results",
+          search: "decks>100 sort:created",
           description:
-            "Combos that are in more than 100 decks, sorted by number of results in ascending order.",
+            "Combos that are in more than 100 decks, sorted by the date they were added to the site.",
         },
       ],
     };

--- a/test/lib/api/parse-query/parse-sort.test.ts
+++ b/test/lib/api/parse-query/parse-sort.test.ts
@@ -14,7 +14,7 @@ describe("parseSort", () => {
     "steps",
     "prerequisites",
     "cards",
-    "id",
+    "created",
     "colors",
     "popularity",
     "price",

--- a/test/lib/api/sort-combos.test.ts
+++ b/test/lib/api/sort-combos.test.ts
@@ -45,7 +45,7 @@ describe("search", () => {
     expect(sortedCombos[4].commanderSpellbookId).toBe("4");
   });
 
-  it("sorts combos by id", () => {
+  it("sorts combos by created at in ascending order", () => {
     combos.push(
       makeFakeCombo({
         commanderSpellbookId: "3",
@@ -57,7 +57,7 @@ describe("search", () => {
         commanderSpellbookId: "1",
       }),
       makeFakeCombo({
-        commanderSpellbookId: "5",
+        commanderSpellbookId: "105",
       }),
       makeFakeCombo({
         commanderSpellbookId: "4",
@@ -65,7 +65,7 @@ describe("search", () => {
     );
 
     const sortedCombos = sortCombos(combos, {
-      by: "id",
+      by: "created",
       order: "ascending",
       vendor: "cardkingdom",
     });
@@ -74,10 +74,10 @@ describe("search", () => {
     expect(sortedCombos[1].commanderSpellbookId).toBe("2");
     expect(sortedCombos[2].commanderSpellbookId).toBe("3");
     expect(sortedCombos[3].commanderSpellbookId).toBe("4");
-    expect(sortedCombos[4].commanderSpellbookId).toBe("5");
+    expect(sortedCombos[4].commanderSpellbookId).toBe("105");
   });
 
-  it("sorts combos by id in descending order", () => {
+  it("sorts combos by created at in descending order", () => {
     combos.push(
       makeFakeCombo({
         commanderSpellbookId: "3",
@@ -89,7 +89,7 @@ describe("search", () => {
         commanderSpellbookId: "1",
       }),
       makeFakeCombo({
-        commanderSpellbookId: "5",
+        commanderSpellbookId: "105",
       }),
       makeFakeCombo({
         commanderSpellbookId: "4",
@@ -97,12 +97,12 @@ describe("search", () => {
     );
 
     const sortedCombos = sortCombos(combos, {
-      by: "id",
+      by: "created",
       order: "descending",
       vendor: "cardkingdom",
     });
 
-    expect(sortedCombos[0].commanderSpellbookId).toBe("5");
+    expect(sortedCombos[0].commanderSpellbookId).toBe("105");
     expect(sortedCombos[1].commanderSpellbookId).toBe("4");
     expect(sortedCombos[2].commanderSpellbookId).toBe("3");
     expect(sortedCombos[3].commanderSpellbookId).toBe("2");
@@ -613,7 +613,7 @@ describe("search", () => {
     }
   );
 
-  it("orders id in asecnding order when auto order is used", () => {
+  it("orders created at in asecnding order when auto order is used", () => {
     combos.push(
       makeFakeCombo({
         commanderSpellbookId: "1",
@@ -636,7 +636,7 @@ describe("search", () => {
     combos.sort(() => 0.5 - Math.random());
 
     sortCombos(combos, {
-      by: "id",
+      by: "created",
       order: "auto",
       vendor: "cardkingdom",
     });


### PR DESCRIPTION
Adds a new sort option to sort by the date it was created. Right now, this just uses the Spellbook ID for each combo. In the future, we'll sort by the actual created date of the object in the database. We'll have to fake this info for combos that are currently active on the site that will need to be migrated to the database.