### PR TITLE
Fixed inconsistent displaying of "legal:commander" being applied to queries by default when it wasn't

### DIFF
--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -60,7 +60,7 @@ const AUTO_SORT_MAP: Record<string, "-"> = {
 const PAGE_SIZE = 50
 
 const doesQuerySpecifyFormat = (query: string) : boolean => {
-  return query.includes('legal:') || query.includes('banned:') || query.includes('restricted:') || query.includes('format:') || query.includes('f:');
+  return query.includes('legal:') || query.includes('banned:')|| query.includes('format:');
 }
 
 const Search: React.FC<Props> = ({combos, count, page, bannedCombos}: Props) => {

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -59,7 +59,7 @@ const AUTO_SORT_MAP: Record<string, "-"> = {
 
 const PAGE_SIZE = 50
 
-const doesQuerySpecifyFormat: boolean = (query: string) => {
+const doesQuerySpecifyFormat = (query: string) : boolean => {
   return query.includes('legal:') || query.includes('banned:') || query.includes('restricted:') || query.includes('format:') || query.includes('f:');
 }
 


### PR DESCRIPTION
Fixes Issue #507 
Now the text being displayed checks the query the same way the function actually sending the query to the server does. Also the query sanitization was not checking all the ways that scryfall allows you to specify formats namely not `f:` or `restricted:`