### PR TITLE
feat(url-support): base functionality added to support url parameter, resolves #550

### DIFF
--- a/cypress/e2e/find-my-combos.cy.ts
+++ b/cypress/e2e/find-my-combos.cy.ts
@@ -1,0 +1,25 @@
+describe('Find My Combos', () => {
+  let testUrl = 'https://www.moxfield.com/decks/chDG34jh6E-vPEugnXO1BA';
+
+  it('can find a combo using url parameter', () => {
+    cy.visit('/find-my-combos/?url=' + testUrl);
+
+    cy.url().should('include', testUrl);
+
+    cy.get('#decklist-input').should('have.length', 1);
+    cy.get('#commander-input').should('have.length', 1);
+  });
+
+  it('can clear the url and data', () => {
+    cy.visit('/find-my-combos/?url=' + testUrl);
+    cy.url().should('include', testUrl);
+
+    cy.get('#clear-decklist-input').click();
+
+    cy.get('#decklist-input').should('be.empty');
+    cy.get('#commander-input').should('be.empty');
+    cy.url().should('not.contain', testUrl);
+  });
+});
+
+export {};

--- a/src/pages/find-my-combos.tsx
+++ b/src/pages/find-my-combos.tsx
@@ -66,6 +66,7 @@ class Decklist {
 const FindMyCombos: React.FC = () => {
   const router = useRouter();
 
+  const { query } = router;
   const [decklist, setDecklist] = useState<string>('');
   const [commanderList, setCommanderList] = useState<string>('');
   const [decklistErrors, setDecklistErrors] = useState<string[]>([]);
@@ -198,6 +199,9 @@ const FindMyCombos: React.FC = () => {
   };
 
   const clearDecklist = () => {
+    if (query.url){
+      router.push({pathname: '/find-my-combos/',query: {}});
+    }
     setCurrentlyParsedDeck(undefined);
     setDecklist('');
     setCommanderList('');
@@ -207,6 +211,18 @@ const FindMyCombos: React.FC = () => {
     setResults(DEFAULT_RESULTS);
     localStorage.removeItem(LOCAL_STORAGE_DECK_STORAGE_KEY);
   };
+
+  useEffect(() => {
+    if (query.url && !deckUrl) {
+      setDeckUrl(decodeURIComponent(query.url as string));
+    }
+  }, [query.url]);
+
+  useEffect(() => {
+    if (query.url && deckUrl) {
+      handleUrlInput();
+    }
+  }, [deckUrl]);
 
   useEffect(() => {
     if (!router.isReady) {
@@ -313,7 +329,7 @@ const FindMyCombos: React.FC = () => {
               {!lookupInProgress && (
                 <>
                   <button
-                    id="clear-decklist-input"
+                    id="parse-decklist-input"
                     className={`${styles.clearDecklistInput} button`}
                     onClick={() => parseDecklist(decklist, commanderList).then((decklist) => lookupCombos(decklist))}
                   >


### PR DESCRIPTION
- Added functionality by grabbing param from the router and then utilizing existing functionality in setDeckUrl.  
- Then had another useEffect to watch and see if a param.url  was set and the deckUrl was set to fire the existing handleUrlInput().
- Made sure you can clear the url from the address bar by clicking the Clear Decklist
- Finally made a test for find-my-combos to walk through a url param being added to the address bar, and that it would appropriately clear.
- (Bonus): there were two <buttons> with the id="clear-decklist-input" changed the other to "parse-decklist-input" as it is firing the parseDecklist function.