### PR TITLE
fix: update readme link Fixes SpaceCowMedia/commander-spellbook-site#552

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Check out the [about page](https://commanderspellbook.com/about/) for details ab
 
 ## Development
 
-See [the development docs](https://edhrec.github.io/commander-spellbook-site/) for information on how to contribute to the site.
+See [the development docs](https://spacecowmedia.github.io/commander-spellbook-site/) for information on how to contribute to the site.


### PR DESCRIPTION
Updated README.md link to https://spacecowmedia.github.io/commander-spellbook-site/