### PR TITLE
fix: deckUrl causing refresh error

### DIFF
--- a/src/pages/find-my-combos.tsx
+++ b/src/pages/find-my-combos.tsx
@@ -268,14 +268,16 @@ const FindMyCombos: React.FC = () => {
   const urlQueryParam = queryParameterAsString(router.query.deckUrl) ?? '';
 
   useEffect(() => {
-    setDeckUrl(urlQueryParam);
+    if (router.query.deckUrl != undefined){
+      setDeckUrl(urlQueryParam);
+    }
   }, [router.query.deckUrl]);
 
   useEffect(() => {
-    if (deckUrl === urlQueryParam) {
+    if (deckUrl === urlQueryParam && urlQueryParam != "") {
       handleUrlInput();
     }
-  }, [deckUrl]);
+  }, [deckUrl,urlQueryParam]);
 
   return (
     <>


### PR DESCRIPTION
- Testing entering url on find-my-combos, received "You must paste a valid url" when I had.
- Submitting the url places the deckUrl in the address bar, but the deck does not load.
- refreshing page loads deckUrl and deck list correctly when deckUrl in address bar

I just did a minor adjustment to make sure the page isn't checking an empty variable, and then added urlQueryParam to be watched as well to handleUrlInput on click where both deckUrl and urlQueryParam are good to go.