### PR TITLE
Enable source maps in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,4 +99,8 @@ ENV PORT=3000
 # set hostname to localhost
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["node", "server.js"]
+CMD [\
+  "node", \
+  "--enable-source-maps", \
+  "server.js" \
+]


### PR DESCRIPTION
Added --enable-source-maps flag to node command in Dockerfile to improve error stack traces in production.

Requested in https://discord.com/channels/752903319072276540/1270112234101543084