### PR TITLE
Feature/532 export combos as txt file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,8 @@ sw.*
 cypress/fixtures
 cypress/videos
 cypress/screenshots
+cypress/downloads
+
 
 # Build files
 tsconfig.tsbuildinfo

--- a/cypress/e2e/download-combos.cy.ts
+++ b/cypress/e2e/download-combos.cy.ts
@@ -1,0 +1,40 @@
+import path from 'path';
+
+describe('Download combos button', () => {
+  const downloadDir = 'cypress/downloads';
+
+  it('Should download file if combos have been found', () => {
+    // GIVEN
+    const searchQuery = 'loot';
+    cy.visit('/search?q=' + searchQuery);
+
+    // WHEN
+    cy.get('#download-combos-btn').click();
+
+    // THEN
+    const comboFileName = 'combos_' + searchQuery + '.txt';
+    cy.readFile(path.join(downloadDir, comboFileName));
+  });
+
+  it('Should concat query word with underscores', () => {
+    // GIVEN
+    const searchQuery = 'selvala, heart of the wilds';
+    cy.visit('/search?q=' + searchQuery);
+
+    // WHEN
+    cy.get('#download-combos-btn').click();
+
+    // THEN
+    const comboFileName = 'combos_selvala_heart_of_the_wilds.txt';
+    cy.readFile(path.join(downloadDir, comboFileName));
+  });
+
+  it('Should not appear if not combo found', () => {
+    // GIVEN
+    const searchQuery = 'dummy-search-impossible-to-find-something';
+    cy.visit('/search?q=' + searchQuery);
+
+    // THEN
+    cy.get('#download-combos-btn').should('not.exist');
+  });
+});

--- a/cypress/e2e/download-combos.cy.ts
+++ b/cypress/e2e/download-combos.cy.ts
@@ -12,20 +12,7 @@ describe('Download combos button', () => {
     cy.get('#download-combos-btn').click();
 
     // THEN
-    const comboFileName = 'combos_' + searchQuery + '.txt';
-    cy.readFile(path.join(downloadDir, comboFileName));
-  });
-
-  it('Should concat query word with underscores', () => {
-    // GIVEN
-    const searchQuery = 'selvala, heart of the wilds';
-    cy.visit('/search?q=' + searchQuery);
-
-    // WHEN
-    cy.get('#download-combos-btn').click();
-
-    // THEN
-    const comboFileName = 'combos_selvala_heart_of_the_wilds.txt';
+    const comboFileName = 'commander_spellbook_combos.txt';
     cy.readFile(path.join(downloadDir, comboFileName));
   });
 

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["cypress"]
+    "types": ["cypress", "node"]
   },
   "include": ["**/*.ts"]
 }

--- a/src/components/search/ComboResults/comboResults.module.scss
+++ b/src/components/search/ComboResults/comboResults.module.scss
@@ -40,6 +40,4 @@
     }
   }
 
-  padding-top: 125px;
-  margin-top: -125px;
 }

--- a/src/pages/search.module.scss
+++ b/src/pages/search.module.scss
@@ -1,0 +1,3 @@
+.exportToTextButton {
+  @apply border border-dark text-dark p-2 rounded-l-sm hover:bg-dark hover:text-white dark:border-white dark:text-white;
+}

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -115,9 +115,8 @@ const Search: React.FC<Props> = ({ combos, count, page, bannedCombos, error, fea
     }
 
     const combosExport = CombosExportService.exportToText(combos);
-    const queryFormated = query.replace(/\s/g, '_').replace(/\W/g, '');
 
-    DownloadFileService.downloadTextFile(`combos_${queryFormated}.txt`, combosExport);
+    DownloadFileService.downloadTextFile('commander_spellbook_combos.txt', combosExport);
   };
 
   const legalityMessage = doesQuerySpecifyFormat(query) ? '' : ' (legal:commander has been applied by default)';

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -12,6 +12,9 @@ import ArtCircle from 'components/layout/ArtCircle/ArtCircle';
 import { Variant, VariantsApi } from '@space-cow-media/spellbook-client';
 import { apiConfiguration } from 'services/api.service';
 import { queryParameterAsString } from 'lib/queryParameters';
+import CombosExportService from 'services/combos-export.service';
+import DownloadFileService from 'services/download-file.service';
+import styles from './search.module.scss';
 
 const PAGE_SIZE = 50;
 
@@ -104,6 +107,15 @@ const Search: React.FC<Props> = ({ combos, count, page, bannedCombos, error, fea
 
   const handleClearVariant = () => {
     router.push({ pathname: '/search/', query: { ...router.query, variant: undefined, page: '1' } });
+  };
+
+  const handleExportCombosToText = () => {
+    if (combos.length === 0) {
+      return;
+    }
+
+    const txt = CombosExportService.exportToText(combos);
+    DownloadFileService.downloadTextFile('combos.txt', txt);
   };
 
   const legalityMessage = doesQuerySpecifyFormat(query) ? '' : ' (legal:commander has been applied by default)';
@@ -202,6 +214,12 @@ const Search: React.FC<Props> = ({ combos, count, page, bannedCombos, error, fea
                   />
                 </>
               )}
+            </div>
+
+            <div className="container sm:flex flex-row mb-2">
+              <button type="button" onClick={handleExportCombosToText} className={styles.exportToTextButton}>
+                Export combos to text
+              </button>
             </div>
           </div>
         )}

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -114,8 +114,10 @@ const Search: React.FC<Props> = ({ combos, count, page, bannedCombos, error, fea
       return;
     }
 
-    const txt = CombosExportService.exportToText(combos);
-    DownloadFileService.downloadTextFile('combos.txt', txt);
+    const combosExport = CombosExportService.exportToText(combos);
+    const queryFormated = query.replace(/\s/g, '_').replace(/\W/g, '');
+
+    DownloadFileService.downloadTextFile(`combos_${queryFormated}.txt`, combosExport);
   };
 
   const legalityMessage = doesQuerySpecifyFormat(query) ? '' : ' (legal:commander has been applied by default)';
@@ -217,7 +219,12 @@ const Search: React.FC<Props> = ({ combos, count, page, bannedCombos, error, fea
             </div>
 
             <div className="container sm:flex flex-row mb-2">
-              <button type="button" onClick={handleExportCombosToText} className={styles.exportToTextButton}>
+              <button
+                id="download-combos-btn"
+                type="button"
+                onClick={handleExportCombosToText}
+                className={styles.exportToTextButton}
+              >
                 Export combos to text
               </button>
             </div>

--- a/src/services/combos-export.service.ts
+++ b/src/services/combos-export.service.ts
@@ -20,12 +20,10 @@ function exportToText(combos: Variant[]): string {
 
   const lines: string[] = [];
 
-  for (let combo of combos) {
-    if (!combo) {
-      continue;
-    }
+  for (let indexCombo = 0; indexCombo < combos.length; indexCombo++) {
+    const combo = combos[indexCombo];
 
-    lines.push('--------------------------------------');
+    lines.push(`${indexCombo + 1}. --------------------------------------`);
     lines.push(getIdentity(combo));
     lines.push(LINE_BREAK);
 

--- a/src/services/combos-export.service.ts
+++ b/src/services/combos-export.service.ts
@@ -1,0 +1,61 @@
+import { Variant } from '@space-cow-media/spellbook-client';
+import { getPrerequisiteList } from 'lib/prerequisitesProcessor';
+
+const LINE_BREAK = '\n';
+
+function getIdentity(combo: Variant): string {
+  let identity = '';
+
+  for (let color of combo.identity.split('')) {
+    identity += '{' + color + '}';
+  }
+
+  return identity;
+}
+
+function exportToText(combos: Variant[]): string {
+  if (!combos) {
+    return '';
+  }
+
+  const lines: string[] = [];
+
+  for (let combo of combos) {
+    if (!combo) {
+      continue;
+    }
+
+    lines.push('--------------------------------------');
+    lines.push(getIdentity(combo));
+    lines.push(LINE_BREAK);
+
+    lines.push('Cards Required:');
+    for (let comboCard of combo.uses) {
+      lines.push(`- ${comboCard.card.name}`);
+    }
+    lines.push(LINE_BREAK);
+
+    lines.push('Prerequisites:');
+    const prerequisites = getPrerequisiteList(combo);
+    for (let prereq of prerequisites) {
+      lines.push(`- ${prereq.description}`);
+    }
+    lines.push(LINE_BREAK);
+
+    lines.push('Steps:');
+    const steps = combo.description.split(LINE_BREAK);
+
+    for (let stepIndex = 0; stepIndex < steps.length; stepIndex++) {
+      lines.push(`${stepIndex + 1}. ${steps[stepIndex]}`);
+    }
+    lines.push(LINE_BREAK);
+  }
+
+  return lines.join(LINE_BREAK);
+}
+
+const CombosExportService = {
+  exportToText,
+};
+
+export default CombosExportService;

--- a/src/services/download-file.service.ts
+++ b/src/services/download-file.service.ts
@@ -1,0 +1,25 @@
+const TEXT_EXTENSION = '.txt';
+
+function downloadTextFile(filename: string, content: string): void {
+  if (!filename || filename.length === 0 || !content || content.length === 0) {
+    return;
+  }
+
+  const textFileName = filename.endsWith(TEXT_EXTENSION) ? filename : filename + TEXT_EXTENSION;
+
+  const element = document.createElement('a');
+  element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(content));
+  element.setAttribute('download', textFileName);
+  element.style.display = 'none';
+
+  document.body.appendChild(element);
+  element.click();
+
+  document.body.removeChild(element);
+}
+
+const DownloadFileService = {
+  downloadTextFile,
+};
+
+export default DownloadFileService;


### PR DESCRIPTION
Resolves #532 

Added a button on the search page to export found combos as a text file (.txt). The format used follows [the example file 1](https://github.com/user-attachments/files/17549377/option1.txt) mentioned in [this comment](https://github.com/SpaceCowMedia/commander-spellbook-site/issues/532#issuecomment-2442776811).

When no combos are found, the button does not appear.

The variants are not listed in the extract. It can be a further source of improvement if needed.

