### PR TITLE
feat: remove sm:w-1/2 from select arrow as it messes with select's placement

### DIFF
--- a/src/components/layout/StyledSelect/StyledSelect.tsx
+++ b/src/components/layout/StyledSelect/StyledSelect.tsx
@@ -54,7 +54,7 @@ const StyledSelect: React.FC<Props> = ({
         ))}
       </select>
       <div className="absolute inset-y-0 right-0 flex items-center px-2 pointer-events-none" aria-hidden="true">
-        <svg className={`${selectTextClassName} w-4 h-4 fill-current`} viewBox="0 0 20 20">
+        <svg className="w-4 h-4 fill-current" viewBox="0 0 20 20">
           <path
             d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
             clipRule="evenodd"


### PR DESCRIPTION
resolves #608 

sm:w-1/2 does not seem to impact arrow's spacement on other browsers nor phone display so I deleted it