### PR TITLE
feat: map mustBeCommander prerequisite to be shown on initial state

### DIFF
--- a/src/components/combo/PrerequisiteList/PrerequisiteList.tsx
+++ b/src/components/combo/PrerequisiteList/PrerequisiteList.tsx
@@ -16,8 +16,9 @@ type Props = {
   fetchTemplateReplacements?: (_template: Template, _page: number) => Promise<ScryfallResultsPage>;
 };
 
-const ICON_MAP: Record<string, SpellbookIcon> = {
+const PREREQ_ICON_MAP: Record<string, SpellbookIcon> = {
   B: 'battlefield',
+  commander: 'commander',
   C: 'commandZone',
   G: 'graveyard',
   H: 'hand',
@@ -34,7 +35,9 @@ const PrerequisiteList: React.FC<Props> = ({
   templatesInCombo,
   fetchTemplateReplacements,
 }) => {
-  const zonePrerequisites = prerequisites.filter((prereq) => prereq.zones.filter((z) => ICON_MAP[z]).length > 0);
+  const initialStatePrerequisites = prerequisites.filter(
+    (prereq) => prereq.zones.filter((z) => PREREQ_ICON_MAP[z]).length > 0,
+  );
   const easyPrerequisites = prerequisites.filter((prereq) => prereq.zones.find((z) => z == 'easy'));
   const notablePrerequisites = prerequisites.filter((prereq) => prereq.zones.find((z) => z == 'notable'));
   const manaNeeded = prerequisites.filter((prereq) => prereq.zones.find((z) => z == 'mana'));
@@ -43,13 +46,13 @@ const PrerequisiteList: React.FC<Props> = ({
       <div className="pr-6 py-4">
         <h2 className="font-bold text-xl mb-2">Initial Card State</h2>
         <ol className="list-inside">
-          {zonePrerequisites.map((prereq, index) => (
+          {initialStatePrerequisites.map((prereq, index) => (
             <li key={`${prereq.zones.join('')}-${index}`}>
               {prereq.zones
-                .filter((z) => ICON_MAP[z])
+                .filter((z) => PREREQ_ICON_MAP[z])
                 .map((z) => (
                   <span key={`${prereq.zones.join('')}-${index}-${z}`}>
-                    <Icon name={ICON_MAP[z]} />
+                    <Icon name={PREREQ_ICON_MAP[z]} />
                     &nbsp;
                   </span>
                 ))}

--- a/src/components/layout/Icon/Icon.tsx
+++ b/src/components/layout/Icon/Icon.tsx
@@ -51,6 +51,7 @@ import React from 'react';
 const SPELLBOOK_ICONS = {
   graveyard: styles.graveyard,
   battlefield: styles.battlefield,
+  commander: styles.commandZone,
   commandZone: styles.commandZone,
   hand: styles.hand,
   library: styles.library,


### PR DESCRIPTION
resolves #714 

If a combo card must be a commander for the combo to work properly, a prerequisite is shown in the "Initial Card State" section.

![image](https://github.com/user-attachments/assets/1403c02c-eb09-45c0-9a0a-2eea7d06bc86)
