### PR TITLE
feat: persist find-my-combos results and scroll position

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -32,10 +32,6 @@ const nextConfig: (phase: string) => NextConfig = (phase) => {
     reactStrictMode: true,
     trailingSlash: true,
     productionBrowserSourceMaps: true,
-    experimental: {
-      // Restore scroll position on browser back/forward across all Pages Router routes.
-      scrollRestoration: true,
-    },
     assetPrefix: !isDev && !isTest ? `https://${dev}cdn.commanderspellbook.com` : undefined,
     images: {
       unoptimized: true,

--- a/next.config.ts
+++ b/next.config.ts
@@ -32,6 +32,10 @@ const nextConfig: (phase: string) => NextConfig = (phase) => {
     reactStrictMode: true,
     trailingSlash: true,
     productionBrowserSourceMaps: true,
+    experimental: {
+      // Restore scroll position on browser back/forward across all Pages Router routes.
+      scrollRestoration: true,
+    },
     assetPrefix: !isDev && !isTest ? `https://${dev}cdn.commanderspellbook.com` : undefined,
     images: {
       unoptimized: true,

--- a/src/components/FindMyCombos/DeckCombos.tsx
+++ b/src/components/FindMyCombos/DeckCombos.tsx
@@ -1,6 +1,7 @@
 import ComboResults from 'components/search/ComboResults/ComboResults';
 import React from 'react';
-import { Decklist, ResultType } from 'pages/find-my-combos';
+import { Decklist } from 'pages/find-my-combos';
+import { ResultType } from 'lib/findMyCombosResultsCache';
 import pluralize from 'pluralize';
 
 interface Props {

--- a/src/lib/findMyCombosResultsCache.ts
+++ b/src/lib/findMyCombosResultsCache.ts
@@ -1,0 +1,50 @@
+import { EstimateBracketResult, Variant } from '@space-cow-media/spellbook-client';
+
+const SESSION_STORAGE_RESULTS_KEY = 'commander-spellbook-combo-finder-results';
+
+export interface ResultType {
+  identity: string;
+  included: Variant[];
+  includedByChangingCommanders: Variant[];
+  almostIncluded: Variant[];
+  almostIncludedByChangingCommanders: Variant[];
+  almostIncludedByAddingColors: Variant[];
+  almostIncludedByAddingColorsAndChangingCommanders: Variant[];
+}
+
+export type ResultsCache = {
+  deckJson: string;
+  format: string;
+  results: ResultType;
+  bracketInfo: EstimateBracketResult | undefined;
+};
+
+export const readResultsCache = (): ResultsCache | null => {
+  try {
+    const raw = sessionStorage.getItem(SESSION_STORAGE_RESULTS_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed: ResultsCache = JSON.parse(raw);
+    return parsed;
+  } catch {
+    return null;
+  }
+};
+
+export const mergeResultsCache = (patch: Partial<ResultsCache>): void => {
+  try {
+    const existing = readResultsCache();
+    sessionStorage.setItem(SESSION_STORAGE_RESULTS_KEY, JSON.stringify({ ...existing, ...patch }));
+  } catch {
+    // sessionStorage is best-effort; if it fails (quota, private mode) the page still works.
+  }
+};
+
+export const clearResultsCache = (): void => {
+  try {
+    sessionStorage.removeItem(SESSION_STORAGE_RESULTS_KEY);
+  } catch {
+    // ignore
+  }
+};

--- a/src/lib/findMyCombosResultsCache.ts
+++ b/src/lib/findMyCombosResultsCache.ts
@@ -2,6 +2,9 @@ import { EstimateBracketResult, Variant } from '@space-cow-media/spellbook-clien
 
 const SESSION_STORAGE_RESULTS_KEY = 'commander-spellbook-combo-finder-results';
 
+// sessionStorage access is best-effort: every call below swallows errors so that
+// quota limits, private-mode restrictions, or malformed entries can't break the page.
+
 export interface ResultType {
   identity: string;
   included: Variant[];
@@ -29,6 +32,7 @@ export const readResultsCache = (): ResultsCache | null => {
     const parsed: ResultsCache = JSON.parse(raw);
     return parsed;
   } catch {
+    /* see file header */
     return null;
   }
 };
@@ -38,7 +42,7 @@ export const mergeResultsCache = (patch: Partial<ResultsCache>): void => {
     const existing = readResultsCache();
     sessionStorage.setItem(SESSION_STORAGE_RESULTS_KEY, JSON.stringify({ ...existing, ...patch }));
   } catch {
-    // sessionStorage is best-effort; if it fails (quota, private mode) the page still works.
+    /* see file header */
   }
 };
 
@@ -46,6 +50,6 @@ export const clearResultsCache = (): void => {
   try {
     sessionStorage.removeItem(SESSION_STORAGE_RESULTS_KEY);
   } catch {
-    // ignore
+    /* see file header */
   }
 };

--- a/src/lib/findMyCombosResultsCache.ts
+++ b/src/lib/findMyCombosResultsCache.ts
@@ -17,6 +17,7 @@ export type ResultsCache = {
   format: string;
   results: ResultType;
   bracketInfo: EstimateBracketResult | undefined;
+  scrollY: number;
 };
 
 export const readResultsCache = (): ResultsCache | null => {

--- a/src/pages/find-my-combos.tsx
+++ b/src/pages/find-my-combos.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
-import pluralize from "pluralize";
-import styles from "./find-my-combos.module.scss";
-import ArtCircle from "../components/layout/ArtCircle/ArtCircle";
-import SpellbookHead from "../components/SpellbookHead/SpellbookHead";
-import { isValidHttpUrl } from "../lib/url-check";
-import ErrorMessage from "components/submission/ErrorMessage/ErrorMessage";
-import { useRouter } from "next/router";
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import pluralize from 'pluralize';
+import styles from './find-my-combos.module.scss';
+import ArtCircle from '../components/layout/ArtCircle/ArtCircle';
+import SpellbookHead from '../components/SpellbookHead/SpellbookHead';
+import { isValidHttpUrl } from '../lib/url-check';
+import ErrorMessage from 'components/submission/ErrorMessage/ErrorMessage';
+import { useRouter } from 'next/router';
 import {
   CardListFromTextApi,
   CardListFromUrlApi,
@@ -17,30 +17,24 @@ import {
   ResponseError,
   EstimateBracketApi,
   EstimateBracketResult,
-} from "@space-cow-media/spellbook-client";
-import { apiConfiguration } from "services/api.service";
-import { queryParameterAsString } from "lib/queryParameters";
-import { LEGALITY_FORMATS } from "lib/types";
-import StyledSelect from "components/layout/StyledSelect/StyledSelect";
-import { DEFAULT_ORDERING } from "lib/constants";
-import {
-  ResultType,
-  clearResultsCache,
-  mergeResultsCache,
-  readResultsCache,
-} from "lib/findMyCombosResultsCache";
-import CombosExportService from "services/combos-export.service";
-import DownloadFileService from "services/download-file.service";
-import normalizeStringInput from "lib/normalizeStringInput";
-import Modal from "components/ui/Modal/Modal";
-import Tab from "components/ui/Tab/Tab.";
-import DeckCombos from "components/FindMyCombos/DeckCombos";
-import DeckBracket from "components/FindMyCombos/DeckBracket";
-import Loader from "components/layout/Loader/Loader";
-import { BRACKET_RANGE_MAP } from "lib/brackets";
+} from '@space-cow-media/spellbook-client';
+import { apiConfiguration } from 'services/api.service';
+import { queryParameterAsString } from 'lib/queryParameters';
+import { LEGALITY_FORMATS } from 'lib/types';
+import StyledSelect from 'components/layout/StyledSelect/StyledSelect';
+import { DEFAULT_ORDERING } from 'lib/constants';
+import { ResultType, clearResultsCache, mergeResultsCache, readResultsCache } from 'lib/findMyCombosResultsCache';
+import CombosExportService from 'services/combos-export.service';
+import DownloadFileService from 'services/download-file.service';
+import normalizeStringInput from 'lib/normalizeStringInput';
+import Modal from 'components/ui/Modal/Modal';
+import Tab from 'components/ui/Tab/Tab.';
+import DeckCombos from 'components/FindMyCombos/DeckCombos';
+import DeckBracket from 'components/FindMyCombos/DeckBracket';
+import Loader from 'components/layout/Loader/Loader';
+import { BRACKET_RANGE_MAP } from 'lib/brackets';
 
-const LOCAL_STORAGE_DECK_STORAGE_KEY =
-  "commander-spellbook-combo-finder-last-decklist";
+const LOCAL_STORAGE_DECK_STORAGE_KEY = 'commander-spellbook-combo-finder-last-decklist';
 
 export class Decklist {
   deck: Deck;
@@ -50,15 +44,11 @@ export class Decklist {
   }
 
   commanderListString(): string {
-    return this.deck.commanders
-      .map((card) => `${card.quantity} ${card.card}`)
-      .join("\n");
+    return this.deck.commanders.map((card) => `${card.quantity} ${card.card}`).join('\n');
   }
 
   mainListString(): string {
-    return this.deck.main
-      .map((card) => `${card.quantity} ${card.card}`)
-      .join("\n");
+    return this.deck.main.map((card) => `${card.quantity} ${card.card}`).join('\n');
   }
 
   toString(): string {
@@ -80,20 +70,20 @@ export class Decklist {
 const FindMyCombos: React.FC = () => {
   const router = useRouter();
   const [exportModalOpen, setExportModalOpen] = useState(false);
-  const [decklist, setDecklist] = useState<string>("");
-  const [commanderList, setCommanderList] = useState<string>("");
+  const [decklist, setDecklist] = useState<string>('');
+  const [commanderList, setCommanderList] = useState<string>('');
   const [decklistErrors, setDecklistErrors] = useState<string[]>([]);
-  const [deckUrl, setDeckUrl] = useState<string>("");
-  const [deckUrlError, setDeckUrlHint] = useState<string>("");
+  const [deckUrl, setDeckUrl] = useState<string>('');
+  const [deckUrlError, setDeckUrlHint] = useState<string>('');
   const [lookupInProgress, setLookupInProgress] = useState<boolean>(false);
   const [currentlyParsedDeck, setCurrentlyParsedDeck] = useState<Decklist>();
-  const [format, setFormat] = useState<string>("commander");
+  const [format, setFormat] = useState<string>('commander');
   // Tracks the format filter the currently-loaded `results` were computed for.
   // The format-change effect re-analyzes only when these diverge, which prevents
   // hydration (which sets `format` from cache) from triggering a redundant fetch.
-  const [analyzedFormat, setAnalyzedFormat] = useState<string>("commander");
+  const [analyzedFormat, setAnalyzedFormat] = useState<string>('commander');
   const numberOfCardsInDeck = currentlyParsedDeck?.countCards() || 0;
-  const numberOfCardsText = `${numberOfCardsInDeck} ${pluralize("card", numberOfCardsInDeck)}`;
+  const numberOfCardsText = `${numberOfCardsInDeck} ${pluralize('card', numberOfCardsInDeck)}`;
   const [results, setResults] = useState<ResultType>();
   const [bracketInfo, setBracketInfo] = useState<EstimateBracketResult>();
   // When restoring from cache, hold the target scroll position until `results` commits.
@@ -112,7 +102,7 @@ const FindMyCombos: React.FC = () => {
     const errorMessages: string[] = [];
     if (Array.isArray(body.main)) {
       body.main.forEach((message: string) => {
-        if (typeof message === "string") {
+        if (typeof message === 'string') {
           errorMessages.push(message);
         }
       });
@@ -128,17 +118,14 @@ const FindMyCombos: React.FC = () => {
     setDecklistErrors(errorMessages);
   };
 
-  const parseDecklist = async (
-    decklistRaw: string,
-    commanderListRaw?: string,
-  ): Promise<Decklist> => {
+  const parseDecklist = async (decklistRaw: string, commanderListRaw?: string): Promise<Decklist> => {
     if (commanderListRaw) {
       decklistRaw = `${decklistRaw}\n// Commanders\n${commanderListRaw}`;
     }
     setDecklist(decklistRaw);
-    setCommanderList(commanderListRaw || "");
+    setCommanderList(commanderListRaw || '');
     setCurrentlyParsedDeck(undefined);
-    setDeckUrl("");
+    setDeckUrl('');
     try {
       const deck = await cardListFromTextApi.cardListFromTextCreate({
         body: decklistRaw,
@@ -167,10 +154,7 @@ const FindMyCombos: React.FC = () => {
       return;
     }
 
-    localStorage.setItem(
-      LOCAL_STORAGE_DECK_STORAGE_KEY,
-      JSON.stringify(DeckToJSON(decklist.deck)),
-    );
+    localStorage.setItem(LOCAL_STORAGE_DECK_STORAGE_KEY, JSON.stringify(DeckToJSON(decklist.deck)));
 
     try {
       const combos = await findMyCombosApi.findMyCombosCreate({
@@ -182,27 +166,20 @@ const FindMyCombos: React.FC = () => {
 
       const newResults = {
         identity: combos.results.identity,
-        included: (forwardedResults?.included || []).concat(
-          combos.results.included,
+        included: (forwardedResults?.included || []).concat(combos.results.included),
+        includedByChangingCommanders: (forwardedResults?.includedByChangingCommanders || []).concat(
+          combos.results.includedByChangingCommanders,
         ),
-        includedByChangingCommanders: (
-          forwardedResults?.includedByChangingCommanders || []
-        ).concat(combos.results.includedByChangingCommanders),
-        almostIncluded: (forwardedResults?.almostIncluded || []).concat(
-          combos.results.almostIncluded,
+        almostIncluded: (forwardedResults?.almostIncluded || []).concat(combos.results.almostIncluded),
+        almostIncludedByChangingCommanders: (forwardedResults?.almostIncludedByChangingCommanders || []).concat(
+          combos.results.almostIncludedByChangingCommanders,
         ),
-        almostIncludedByChangingCommanders: (
-          forwardedResults?.almostIncludedByChangingCommanders || []
-        ).concat(combos.results.almostIncludedByChangingCommanders),
-        almostIncludedByAddingColors: (
-          forwardedResults?.almostIncludedByAddingColors || []
-        ).concat(combos.results.almostIncludedByAddingColors),
+        almostIncludedByAddingColors: (forwardedResults?.almostIncludedByAddingColors || []).concat(
+          combos.results.almostIncludedByAddingColors,
+        ),
         almostIncludedByAddingColorsAndChangingCommanders: (
-          forwardedResults?.almostIncludedByAddingColorsAndChangingCommanders ||
-          []
-        ).concat(
-          combos.results.almostIncludedByAddingColorsAndChangingCommanders,
-        ),
+          forwardedResults?.almostIncludedByAddingColorsAndChangingCommanders || []
+        ).concat(combos.results.almostIncludedByAddingColorsAndChangingCommanders),
       };
 
       const resultCount =
@@ -243,24 +220,24 @@ const FindMyCombos: React.FC = () => {
         bracketInfo,
       });
     } catch (error) {
-      console.error("Failed to fetch bracket info", error);
+      console.error('Failed to fetch bracket info', error);
       setBracketInfo(undefined);
     }
   };
 
   const clearDecklist = () => {
     setCurrentlyParsedDeck(undefined);
-    setDecklist("");
-    setCommanderList("");
-    setDeckUrl("");
-    setDeckUrlHint("");
+    setDecklist('');
+    setCommanderList('');
+    setDeckUrl('');
+    setDeckUrlHint('');
     setDecklistErrors([]);
     setResults(undefined);
     setBracketInfo(undefined);
     localStorage.removeItem(LOCAL_STORAGE_DECK_STORAGE_KEY);
     clearResultsCache();
     if (router.query.deckUrl) {
-      router.push({ pathname: "/find-my-combos/", query: {} });
+      router.push({ pathname: '/find-my-combos/', query: {} });
     }
   };
 
@@ -307,9 +284,9 @@ const FindMyCombos: React.FC = () => {
       }
       mergeResultsCache({ scrollY: window.scrollY });
     };
-    router.events.on("routeChangeStart", handleRouteChangeStart);
+    router.events.on('routeChangeStart', handleRouteChangeStart);
     return () => {
-      router.events.off("routeChangeStart", handleRouteChangeStart);
+      router.events.off('routeChangeStart', handleRouteChangeStart);
     };
   }, [router.events]);
 
@@ -319,8 +296,8 @@ const FindMyCombos: React.FC = () => {
     }
 
     if (router.query.decklist || router.query.commanders) {
-      const decklist = (router.query.decklist as string) || "";
-      const commanderList = (router.query.commanders as string) || "";
+      const decklist = (router.query.decklist as string) || '';
+      const commanderList = (router.query.commanders as string) || '';
       parseDecklist(decklist, commanderList).then((parsed) => {
         if (tryHydrateFromCache(parsed)) {
           return;
@@ -330,9 +307,7 @@ const FindMyCombos: React.FC = () => {
       return;
     }
 
-    const savedDeckString = localStorage.getItem(
-      LOCAL_STORAGE_DECK_STORAGE_KEY,
-    );
+    const savedDeckString = localStorage.getItem(LOCAL_STORAGE_DECK_STORAGE_KEY);
     if (!savedDeckString) {
       return;
     }
@@ -348,7 +323,7 @@ const FindMyCombos: React.FC = () => {
       }
       analyzeDeck(decklist);
     } catch (e) {
-      console.error("Failed to load saved decklist from local storage", e);
+      console.error('Failed to load saved decklist from local storage', e);
       clearDecklist();
     }
   }, [router.isReady]);
@@ -359,14 +334,14 @@ const FindMyCombos: React.FC = () => {
 
   const handleUrlInput = async () => {
     if (!isValidHttpUrl(deckUrl)) {
-      setDeckUrlHint("You must paste a valid URL.");
+      setDeckUrlHint('You must paste a valid URL.');
       return;
     }
     try {
       const deck = await cardListFromUrlApi.cardListFromUrlRetrieve({
         url: deckUrl,
       });
-      setDeckUrlHint("");
+      setDeckUrlHint('');
       const decklist = new Decklist(deck);
       setDecklist(decklist.mainListString());
       setCommanderList(decklist.commanderListString());
@@ -379,7 +354,7 @@ const FindMyCombos: React.FC = () => {
     }
   };
 
-  const urlQueryParam = queryParameterAsString(router.query.deckUrl) ?? "";
+  const urlQueryParam = queryParameterAsString(router.query.deckUrl) ?? '';
 
   useEffect(() => {
     if (router.query.deckUrl != undefined) {
@@ -388,7 +363,7 @@ const FindMyCombos: React.FC = () => {
   }, [router.query.deckUrl]);
 
   useEffect(() => {
-    if (deckUrl === urlQueryParam && urlQueryParam != "") {
+    if (deckUrl === urlQueryParam && urlQueryParam != '') {
       handleUrlInput();
     }
   }, [deckUrl, urlQueryParam]);
@@ -407,12 +382,12 @@ const FindMyCombos: React.FC = () => {
     const commandersNormalized = currentlyParsedDeck
       ? currentlyParsedDeck.deck.commanders
           .map((c) => normalizeStringInput(c.card))
-          .join("+")
+          .join('+')
           .trim()
-          .replace(/\s+/g, "_")
+          .replace(/\s+/g, '_')
           .substring(0, 50)
-      : "";
-    return `${commandersNormalized ? `${commandersNormalized}_` : ""}decklist_combos`;
+      : '';
+    return `${commandersNormalized ? `${commandersNormalized}_` : ''}decklist_combos`;
   };
 
   const handleExportCombosToText = () => {
@@ -421,10 +396,7 @@ const FindMyCombos: React.FC = () => {
     }
 
     const combosExport = CombosExportService.exportToText(results.included);
-    DownloadFileService.downloadTextFile(
-      `${getNormalizedFileName()}.txt`,
-      combosExport,
-    );
+    DownloadFileService.downloadTextFile(`${getNormalizedFileName()}.txt`, combosExport);
   };
 
   const handleExportCombosToCsv = () => {
@@ -433,10 +405,7 @@ const FindMyCombos: React.FC = () => {
     }
 
     const combosExport = CombosExportService.exportToCsv(results.included);
-    DownloadFileService.downloadTextFile(
-      `${getNormalizedFileName()}.csv`,
-      combosExport,
-    );
+    DownloadFileService.downloadTextFile(`${getNormalizedFileName()}.csv`, combosExport);
   };
 
   return (
@@ -452,8 +421,7 @@ const FindMyCombos: React.FC = () => {
           Uncover combos in your deck, and discover potential combos.
         </h2>
         <label htmlFor="decklist-input" className="sr-only">
-          Copy and paste your decklist into the text box to discover the combos
-          in your deck.
+          Copy and paste your decklist into the text box to discover the combos in your deck.
         </label>
         <section>
           <label>Commanders:</label>
@@ -496,14 +464,8 @@ const FindMyCombos: React.FC = () => {
                       id="parse-decklist-input"
                       className={`${styles.clearDecklistInput} button`}
                       onClick={() => {
-                        window.history.replaceState(
-                          null,
-                          "",
-                          "/find-my-combos/",
-                        );
-                        parseDecklist(decklist, commanderList).then(
-                          analyzeDeck,
-                        );
+                        window.history.replaceState(null, '', '/find-my-combos/');
+                        parseDecklist(decklist, commanderList).then(analyzeDeck);
                       }}
                     >
                       Find New Combos!
@@ -518,45 +480,39 @@ const FindMyCombos: React.FC = () => {
                     </button>
                   </div>
 
-                  {decklistErrors.length === 0 &&
-                    results &&
-                    results.included.length > 0 && (
-                      <>
-                        <Modal
-                          open={exportModalOpen}
-                          onClose={() => setExportModalOpen(false)}
-                          closeIcon={true}
-                        >
-                          <h2>Select a file format to export combos</h2>
-                          <div className="flex flex-row gap-y-2">
-                            <button
-                              id="download-combos-txt-btn"
-                              type="button"
-                              className={`${styles.exportCombosInput} button`}
-                              onClick={handleExportCombosToText}
-                            >
-                              TXT
-                            </button>
-                            <button
-                              id="download-combos-csv-btn"
-                              type="button"
-                              className={`${styles.exportCombosInput} button`}
-                              onClick={handleExportCombosToCsv}
-                            >
-                              CSV
-                            </button>
-                          </div>
-                        </Modal>
-                        <button
-                          id="download-combos-file-btn"
-                          type="button"
-                          className={`${styles.exportCombosInput} button`}
-                          onClick={() => setExportModalOpen(true)}
-                        >
-                          Export Combos To File
-                        </button>
-                      </>
-                    )}
+                  {decklistErrors.length === 0 && results && results.included.length > 0 && (
+                    <>
+                      <Modal open={exportModalOpen} onClose={() => setExportModalOpen(false)} closeIcon={true}>
+                        <h2>Select a file format to export combos</h2>
+                        <div className="flex flex-row gap-y-2">
+                          <button
+                            id="download-combos-txt-btn"
+                            type="button"
+                            className={`${styles.exportCombosInput} button`}
+                            onClick={handleExportCombosToText}
+                          >
+                            TXT
+                          </button>
+                          <button
+                            id="download-combos-csv-btn"
+                            type="button"
+                            className={`${styles.exportCombosInput} button`}
+                            onClick={handleExportCombosToCsv}
+                          >
+                            CSV
+                          </button>
+                        </div>
+                      </Modal>
+                      <button
+                        id="download-combos-file-btn"
+                        type="button"
+                        className={`${styles.exportCombosInput} button`}
+                        onClick={() => setExportModalOpen(true)}
+                      >
+                        Export Combos To File
+                      </button>
+                    </>
+                  )}
                 </div>
               )}
               {decklistErrors.map((error) => (
@@ -566,11 +522,7 @@ const FindMyCombos: React.FC = () => {
           )}
 
           {!decklist && (
-            <div
-              id="decklist-hint"
-              className={`${styles.decklistHint} heading-subtitle`}
-              aria-hidden="true"
-            >
+            <div id="decklist-hint" className={`${styles.decklistHint} heading-subtitle`} aria-hidden="true">
               Paste your decklist
             </div>
           )}
@@ -586,16 +538,12 @@ const FindMyCombos: React.FC = () => {
                 placeholder="Supported deckbuilding sites: Archidekt, Moxfield, Deckstats.net, TappedOut.net."
                 onChange={(e) => setDeckUrl(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") {
+                  if (e.key === 'Enter') {
                     handleUrlInput();
                   }
                 }}
               />
-              <div
-                id="decklist-url-hint"
-                className={`${styles.decklistHint} heading-subtitle`}
-                aria-hidden="true"
-              >
+              <div id="decklist-url-hint" className={`${styles.decklistHint} heading-subtitle`} aria-hidden="true">
                 Paste your decklist url
               </div>
               {!!deckUrl && (
@@ -604,7 +552,7 @@ const FindMyCombos: React.FC = () => {
                   className={`${styles.clearDecklistInput} button`}
                   onClick={() =>
                     router.push({
-                      pathname: "/find-my-combos/",
+                      pathname: '/find-my-combos/',
                       query: { deckUrl },
                     })
                   }
@@ -634,28 +582,18 @@ const FindMyCombos: React.FC = () => {
           </div>
         </section>
         {currentlyParsedDeck &&
-          (format === "commander" ? (
+          (format === 'commander' ? (
             <Tab
               tabs={[
                 {
                   title: <>Combos&nbsp;{lookupInProgress && <Loader />}</>,
-                  content: (
-                    <DeckCombos
-                      results={results}
-                      format={format}
-                      currentlyParsedDeck={currentlyParsedDeck}
-                    />
-                  ),
+                  content: <DeckCombos results={results} format={format} currentlyParsedDeck={currentlyParsedDeck} />,
                 },
                 {
                   title: (
                     <>
                       Bracket Info&nbsp;
-                      {bracketInfo ? (
-                        `(Est. ${BRACKET_RANGE_MAP[bracketInfo.bracketTag]})`
-                      ) : (
-                        <Loader />
-                      )}
+                      {bracketInfo ? `(Est. ${BRACKET_RANGE_MAP[bracketInfo.bracketTag]})` : <Loader />}
                     </>
                   ),
                   content: <DeckBracket results={bracketInfo} />,
@@ -663,11 +601,7 @@ const FindMyCombos: React.FC = () => {
               ]}
             />
           ) : (
-            <DeckCombos
-              results={results}
-              format={format}
-              currentlyParsedDeck={currentlyParsedDeck}
-            />
+            <DeckCombos results={results} format={format} currentlyParsedDeck={currentlyParsedDeck} />
           ))}
       </div>
     </>

--- a/src/pages/find-my-combos.tsx
+++ b/src/pages/find-my-combos.tsx
@@ -12,7 +12,6 @@ import {
   Deck,
   FindMyCombosApi,
   InvalidUrlResponse,
-  Variant,
   DeckToJSON,
   DeckFromJSON,
   ResponseError,
@@ -24,6 +23,7 @@ import { queryParameterAsString } from 'lib/queryParameters';
 import { LEGALITY_FORMATS } from 'lib/types';
 import StyledSelect from 'components/layout/StyledSelect/StyledSelect';
 import { DEFAULT_ORDERING } from 'lib/constants';
+import { ResultType, clearResultsCache, mergeResultsCache, readResultsCache } from 'lib/findMyCombosResultsCache';
 import CombosExportService from 'services/combos-export.service';
 import DownloadFileService from 'services/download-file.service';
 import normalizeStringInput from 'lib/normalizeStringInput';
@@ -67,15 +67,7 @@ export class Decklist {
   }
 }
 
-export interface ResultType {
-  identity: string;
-  included: Variant[];
-  includedByChangingCommanders: Variant[];
-  almostIncluded: Variant[];
-  almostIncludedByChangingCommanders: Variant[];
-  almostIncludedByAddingColors: Variant[];
-  almostIncludedByAddingColorsAndChangingCommanders: Variant[];
-}
+export type { ResultType } from 'lib/findMyCombosResultsCache';
 
 const FindMyCombos: React.FC = () => {
   const router = useRouter();
@@ -88,6 +80,10 @@ const FindMyCombos: React.FC = () => {
   const [lookupInProgress, setLookupInProgress] = useState<boolean>(false);
   const [currentlyParsedDeck, setCurrentlyParsedDeck] = useState<Decklist>();
   const [format, setFormat] = useState<string>('commander');
+  // Tracks the format filter the currently-loaded `results` were computed for.
+  // The format-change effect re-analyzes only when these diverge, which prevents
+  // hydration (which sets `format` from cache) from triggering a redundant fetch.
+  const [analyzedFormat, setAnalyzedFormat] = useState<string>('commander');
   const numberOfCardsInDeck = currentlyParsedDeck?.countCards() || 0;
   const numberOfCardsText = `${numberOfCardsInDeck} ${pluralize('card', numberOfCardsInDeck)}`;
   const [results, setResults] = useState<ResultType>();
@@ -197,6 +193,12 @@ const FindMyCombos: React.FC = () => {
       } // Adding a page limit to prevent infinite loops
 
       setResults(newResults);
+      setAnalyzedFormat(format);
+      mergeResultsCache({
+        deckJson: JSON.stringify(DeckToJSON(decklist.deck)),
+        format,
+        results: newResults,
+      });
     } catch (error) {
       await handleFindMyCombosError(error);
       setResults(undefined);
@@ -211,6 +213,10 @@ const FindMyCombos: React.FC = () => {
         deckRequest: decklist.deck,
       });
       setBracketInfo(bracketInfo);
+      mergeResultsCache({
+        deckJson: JSON.stringify(DeckToJSON(decklist.deck)),
+        bracketInfo,
+      });
     } catch (error) {
       console.error('Failed to fetch bracket info', error);
       setBracketInfo(undefined);
@@ -227,6 +233,7 @@ const FindMyCombos: React.FC = () => {
     setResults(undefined);
     setBracketInfo(undefined);
     localStorage.removeItem(LOCAL_STORAGE_DECK_STORAGE_KEY);
+    clearResultsCache();
     if (router.query.deckUrl) {
       router.push({ pathname: '/find-my-combos/', query: {} });
     }
@@ -237,6 +244,26 @@ const FindMyCombos: React.FC = () => {
     lookupBracket(decklist);
   };
 
+  const tryHydrateFromCache = (decklist: Decklist): boolean => {
+    if (decklist.isEmpty()) {
+      return false;
+    }
+    const cache = readResultsCache();
+    if (!cache) {
+      return false;
+    }
+    const deckJson = JSON.stringify(DeckToJSON(decklist.deck));
+    if (cache.deckJson !== deckJson) {
+      clearResultsCache();
+      return false;
+    }
+    setResults(cache.results);
+    setBracketInfo(cache.bracketInfo);
+    setFormat(cache.format);
+    setAnalyzedFormat(cache.format);
+    return true;
+  };
+
   useEffect(() => {
     if (!router.isReady) {
       return;
@@ -245,7 +272,12 @@ const FindMyCombos: React.FC = () => {
     if (router.query.decklist || router.query.commanders) {
       const decklist = (router.query.decklist as string) || '';
       const commanderList = (router.query.commanders as string) || '';
-      parseDecklist(decklist, commanderList).then(analyzeDeck);
+      parseDecklist(decklist, commanderList).then((parsed) => {
+        if (tryHydrateFromCache(parsed)) {
+          return;
+        }
+        analyzeDeck(parsed);
+      });
       return;
     }
 
@@ -260,6 +292,9 @@ const FindMyCombos: React.FC = () => {
       setDecklist(decklist.mainListString());
       setCommanderList(decklist.commanderListString());
       setCurrentlyParsedDeck(decklist);
+      if (tryHydrateFromCache(decklist)) {
+        return;
+      }
       analyzeDeck(decklist);
     } catch (e) {
       console.error('Failed to load saved decklist from local storage', e);
@@ -308,10 +343,14 @@ const FindMyCombos: React.FC = () => {
   }, [deckUrl, urlQueryParam]);
 
   useEffect(() => {
-    if (currentlyParsedDeck) {
-      analyzeDeck(currentlyParsedDeck);
+    if (!currentlyParsedDeck) {
+      return;
     }
-  }, [format]);
+    if (format === analyzedFormat) {
+      return;
+    }
+    analyzeDeck(currentlyParsedDeck);
+  }, [format, analyzedFormat, currentlyParsedDeck]);
 
   const getNormalizedFileName = () => {
     const commandersNormalized = currentlyParsedDeck

--- a/src/pages/find-my-combos.tsx
+++ b/src/pages/find-my-combos.tsx
@@ -198,6 +198,7 @@ const FindMyCombos: React.FC = () => {
         deckJson: JSON.stringify(DeckToJSON(decklist.deck)),
         format,
         results: newResults,
+        scrollY: 0,
       });
     } catch (error) {
       await handleFindMyCombosError(error);
@@ -261,8 +262,25 @@ const FindMyCombos: React.FC = () => {
     setBracketInfo(cache.bracketInfo);
     setFormat(cache.format);
     setAnalyzedFormat(cache.format);
+    const targetScrollY = cache.scrollY;
+    requestAnimationFrame(() => {
+      window.scrollTo(0, targetScrollY);
+    });
     return true;
   };
+
+  useEffect(() => {
+    const handleRouteChangeStart = () => {
+      if (!readResultsCache()) {
+        return;
+      }
+      mergeResultsCache({ scrollY: window.scrollY });
+    };
+    router.events.on('routeChangeStart', handleRouteChangeStart);
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChangeStart);
+    };
+  }, [router.events]);
 
   useEffect(() => {
     if (!router.isReady) {

--- a/src/pages/find-my-combos.tsx
+++ b/src/pages/find-my-combos.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useState } from 'react';
-import pluralize from 'pluralize';
-import styles from './find-my-combos.module.scss';
-import ArtCircle from '../components/layout/ArtCircle/ArtCircle';
-import SpellbookHead from '../components/SpellbookHead/SpellbookHead';
-import { isValidHttpUrl } from '../lib/url-check';
-import ErrorMessage from 'components/submission/ErrorMessage/ErrorMessage';
-import { useRouter } from 'next/router';
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import pluralize from "pluralize";
+import styles from "./find-my-combos.module.scss";
+import ArtCircle from "../components/layout/ArtCircle/ArtCircle";
+import SpellbookHead from "../components/SpellbookHead/SpellbookHead";
+import { isValidHttpUrl } from "../lib/url-check";
+import ErrorMessage from "components/submission/ErrorMessage/ErrorMessage";
+import { useRouter } from "next/router";
 import {
   CardListFromTextApi,
   CardListFromUrlApi,
@@ -17,24 +17,30 @@ import {
   ResponseError,
   EstimateBracketApi,
   EstimateBracketResult,
-} from '@space-cow-media/spellbook-client';
-import { apiConfiguration } from 'services/api.service';
-import { queryParameterAsString } from 'lib/queryParameters';
-import { LEGALITY_FORMATS } from 'lib/types';
-import StyledSelect from 'components/layout/StyledSelect/StyledSelect';
-import { DEFAULT_ORDERING } from 'lib/constants';
-import { ResultType, clearResultsCache, mergeResultsCache, readResultsCache } from 'lib/findMyCombosResultsCache';
-import CombosExportService from 'services/combos-export.service';
-import DownloadFileService from 'services/download-file.service';
-import normalizeStringInput from 'lib/normalizeStringInput';
-import Modal from 'components/ui/Modal/Modal';
-import Tab from 'components/ui/Tab/Tab.';
-import DeckCombos from 'components/FindMyCombos/DeckCombos';
-import DeckBracket from 'components/FindMyCombos/DeckBracket';
-import Loader from 'components/layout/Loader/Loader';
-import { BRACKET_RANGE_MAP } from 'lib/brackets';
+} from "@space-cow-media/spellbook-client";
+import { apiConfiguration } from "services/api.service";
+import { queryParameterAsString } from "lib/queryParameters";
+import { LEGALITY_FORMATS } from "lib/types";
+import StyledSelect from "components/layout/StyledSelect/StyledSelect";
+import { DEFAULT_ORDERING } from "lib/constants";
+import {
+  ResultType,
+  clearResultsCache,
+  mergeResultsCache,
+  readResultsCache,
+} from "lib/findMyCombosResultsCache";
+import CombosExportService from "services/combos-export.service";
+import DownloadFileService from "services/download-file.service";
+import normalizeStringInput from "lib/normalizeStringInput";
+import Modal from "components/ui/Modal/Modal";
+import Tab from "components/ui/Tab/Tab.";
+import DeckCombos from "components/FindMyCombos/DeckCombos";
+import DeckBracket from "components/FindMyCombos/DeckBracket";
+import Loader from "components/layout/Loader/Loader";
+import { BRACKET_RANGE_MAP } from "lib/brackets";
 
-const LOCAL_STORAGE_DECK_STORAGE_KEY = 'commander-spellbook-combo-finder-last-decklist';
+const LOCAL_STORAGE_DECK_STORAGE_KEY =
+  "commander-spellbook-combo-finder-last-decklist";
 
 export class Decklist {
   deck: Deck;
@@ -44,11 +50,15 @@ export class Decklist {
   }
 
   commanderListString(): string {
-    return this.deck.commanders.map((card) => `${card.quantity} ${card.card}`).join('\n');
+    return this.deck.commanders
+      .map((card) => `${card.quantity} ${card.card}`)
+      .join("\n");
   }
 
   mainListString(): string {
-    return this.deck.main.map((card) => `${card.quantity} ${card.card}`).join('\n');
+    return this.deck.main
+      .map((card) => `${card.quantity} ${card.card}`)
+      .join("\n");
   }
 
   toString(): string {
@@ -67,27 +77,28 @@ export class Decklist {
   }
 }
 
-export type { ResultType } from 'lib/findMyCombosResultsCache';
-
 const FindMyCombos: React.FC = () => {
   const router = useRouter();
   const [exportModalOpen, setExportModalOpen] = useState(false);
-  const [decklist, setDecklist] = useState<string>('');
-  const [commanderList, setCommanderList] = useState<string>('');
+  const [decklist, setDecklist] = useState<string>("");
+  const [commanderList, setCommanderList] = useState<string>("");
   const [decklistErrors, setDecklistErrors] = useState<string[]>([]);
-  const [deckUrl, setDeckUrl] = useState<string>('');
-  const [deckUrlError, setDeckUrlHint] = useState<string>('');
+  const [deckUrl, setDeckUrl] = useState<string>("");
+  const [deckUrlError, setDeckUrlHint] = useState<string>("");
   const [lookupInProgress, setLookupInProgress] = useState<boolean>(false);
   const [currentlyParsedDeck, setCurrentlyParsedDeck] = useState<Decklist>();
-  const [format, setFormat] = useState<string>('commander');
+  const [format, setFormat] = useState<string>("commander");
   // Tracks the format filter the currently-loaded `results` were computed for.
   // The format-change effect re-analyzes only when these diverge, which prevents
   // hydration (which sets `format` from cache) from triggering a redundant fetch.
-  const [analyzedFormat, setAnalyzedFormat] = useState<string>('commander');
+  const [analyzedFormat, setAnalyzedFormat] = useState<string>("commander");
   const numberOfCardsInDeck = currentlyParsedDeck?.countCards() || 0;
-  const numberOfCardsText = `${numberOfCardsInDeck} ${pluralize('card', numberOfCardsInDeck)}`;
+  const numberOfCardsText = `${numberOfCardsInDeck} ${pluralize("card", numberOfCardsInDeck)}`;
   const [results, setResults] = useState<ResultType>();
   const [bracketInfo, setBracketInfo] = useState<EstimateBracketResult>();
+  // When restoring from cache, hold the target scroll position until `results` commits.
+  // useLayoutEffect below applies it before paint so we never scroll into a still-empty page.
+  const pendingScrollY = useRef<number | null>(null);
 
   const configuration = apiConfiguration();
   const findMyCombosApi = new FindMyCombosApi(configuration);
@@ -101,7 +112,7 @@ const FindMyCombos: React.FC = () => {
     const errorMessages: string[] = [];
     if (Array.isArray(body.main)) {
       body.main.forEach((message: string) => {
-        if (typeof message === 'string') {
+        if (typeof message === "string") {
           errorMessages.push(message);
         }
       });
@@ -117,14 +128,17 @@ const FindMyCombos: React.FC = () => {
     setDecklistErrors(errorMessages);
   };
 
-  const parseDecklist = async (decklistRaw: string, commanderListRaw?: string): Promise<Decklist> => {
+  const parseDecklist = async (
+    decklistRaw: string,
+    commanderListRaw?: string,
+  ): Promise<Decklist> => {
     if (commanderListRaw) {
       decklistRaw = `${decklistRaw}\n// Commanders\n${commanderListRaw}`;
     }
     setDecklist(decklistRaw);
-    setCommanderList(commanderListRaw || '');
+    setCommanderList(commanderListRaw || "");
     setCurrentlyParsedDeck(undefined);
-    setDeckUrl('');
+    setDeckUrl("");
     try {
       const deck = await cardListFromTextApi.cardListFromTextCreate({
         body: decklistRaw,
@@ -153,7 +167,10 @@ const FindMyCombos: React.FC = () => {
       return;
     }
 
-    localStorage.setItem(LOCAL_STORAGE_DECK_STORAGE_KEY, JSON.stringify(DeckToJSON(decklist.deck)));
+    localStorage.setItem(
+      LOCAL_STORAGE_DECK_STORAGE_KEY,
+      JSON.stringify(DeckToJSON(decklist.deck)),
+    );
 
     try {
       const combos = await findMyCombosApi.findMyCombosCreate({
@@ -165,20 +182,27 @@ const FindMyCombos: React.FC = () => {
 
       const newResults = {
         identity: combos.results.identity,
-        included: (forwardedResults?.included || []).concat(combos.results.included),
-        includedByChangingCommanders: (forwardedResults?.includedByChangingCommanders || []).concat(
-          combos.results.includedByChangingCommanders,
+        included: (forwardedResults?.included || []).concat(
+          combos.results.included,
         ),
-        almostIncluded: (forwardedResults?.almostIncluded || []).concat(combos.results.almostIncluded),
-        almostIncludedByChangingCommanders: (forwardedResults?.almostIncludedByChangingCommanders || []).concat(
-          combos.results.almostIncludedByChangingCommanders,
+        includedByChangingCommanders: (
+          forwardedResults?.includedByChangingCommanders || []
+        ).concat(combos.results.includedByChangingCommanders),
+        almostIncluded: (forwardedResults?.almostIncluded || []).concat(
+          combos.results.almostIncluded,
         ),
-        almostIncludedByAddingColors: (forwardedResults?.almostIncludedByAddingColors || []).concat(
-          combos.results.almostIncludedByAddingColors,
-        ),
+        almostIncludedByChangingCommanders: (
+          forwardedResults?.almostIncludedByChangingCommanders || []
+        ).concat(combos.results.almostIncludedByChangingCommanders),
+        almostIncludedByAddingColors: (
+          forwardedResults?.almostIncludedByAddingColors || []
+        ).concat(combos.results.almostIncludedByAddingColors),
         almostIncludedByAddingColorsAndChangingCommanders: (
-          forwardedResults?.almostIncludedByAddingColorsAndChangingCommanders || []
-        ).concat(combos.results.almostIncludedByAddingColorsAndChangingCommanders),
+          forwardedResults?.almostIncludedByAddingColorsAndChangingCommanders ||
+          []
+        ).concat(
+          combos.results.almostIncludedByAddingColorsAndChangingCommanders,
+        ),
       };
 
       const resultCount =
@@ -219,24 +243,24 @@ const FindMyCombos: React.FC = () => {
         bracketInfo,
       });
     } catch (error) {
-      console.error('Failed to fetch bracket info', error);
+      console.error("Failed to fetch bracket info", error);
       setBracketInfo(undefined);
     }
   };
 
   const clearDecklist = () => {
     setCurrentlyParsedDeck(undefined);
-    setDecklist('');
-    setCommanderList('');
-    setDeckUrl('');
-    setDeckUrlHint('');
+    setDecklist("");
+    setCommanderList("");
+    setDeckUrl("");
+    setDeckUrlHint("");
     setDecklistErrors([]);
     setResults(undefined);
     setBracketInfo(undefined);
     localStorage.removeItem(LOCAL_STORAGE_DECK_STORAGE_KEY);
     clearResultsCache();
     if (router.query.deckUrl) {
-      router.push({ pathname: '/find-my-combos/', query: {} });
+      router.push({ pathname: "/find-my-combos/", query: {} });
     }
   };
 
@@ -258,16 +282,23 @@ const FindMyCombos: React.FC = () => {
       clearResultsCache();
       return false;
     }
+    pendingScrollY.current = cache.scrollY;
     setResults(cache.results);
     setBracketInfo(cache.bracketInfo);
     setFormat(cache.format);
     setAnalyzedFormat(cache.format);
-    const targetScrollY = cache.scrollY;
-    requestAnimationFrame(() => {
-      window.scrollTo(0, targetScrollY);
-    });
     return true;
   };
+
+  // Persist the scroll position after navigating to a combo detail page
+  useLayoutEffect(() => {
+    if (pendingScrollY.current === null || !results) {
+      return;
+    }
+    const target = pendingScrollY.current;
+    pendingScrollY.current = null;
+    window.scrollTo(0, target);
+  }, [results]);
 
   useEffect(() => {
     const handleRouteChangeStart = () => {
@@ -276,9 +307,9 @@ const FindMyCombos: React.FC = () => {
       }
       mergeResultsCache({ scrollY: window.scrollY });
     };
-    router.events.on('routeChangeStart', handleRouteChangeStart);
+    router.events.on("routeChangeStart", handleRouteChangeStart);
     return () => {
-      router.events.off('routeChangeStart', handleRouteChangeStart);
+      router.events.off("routeChangeStart", handleRouteChangeStart);
     };
   }, [router.events]);
 
@@ -288,8 +319,8 @@ const FindMyCombos: React.FC = () => {
     }
 
     if (router.query.decklist || router.query.commanders) {
-      const decklist = (router.query.decklist as string) || '';
-      const commanderList = (router.query.commanders as string) || '';
+      const decklist = (router.query.decklist as string) || "";
+      const commanderList = (router.query.commanders as string) || "";
       parseDecklist(decklist, commanderList).then((parsed) => {
         if (tryHydrateFromCache(parsed)) {
           return;
@@ -299,7 +330,9 @@ const FindMyCombos: React.FC = () => {
       return;
     }
 
-    const savedDeckString = localStorage.getItem(LOCAL_STORAGE_DECK_STORAGE_KEY);
+    const savedDeckString = localStorage.getItem(
+      LOCAL_STORAGE_DECK_STORAGE_KEY,
+    );
     if (!savedDeckString) {
       return;
     }
@@ -315,7 +348,7 @@ const FindMyCombos: React.FC = () => {
       }
       analyzeDeck(decklist);
     } catch (e) {
-      console.error('Failed to load saved decklist from local storage', e);
+      console.error("Failed to load saved decklist from local storage", e);
       clearDecklist();
     }
   }, [router.isReady]);
@@ -326,14 +359,14 @@ const FindMyCombos: React.FC = () => {
 
   const handleUrlInput = async () => {
     if (!isValidHttpUrl(deckUrl)) {
-      setDeckUrlHint('You must paste a valid URL.');
+      setDeckUrlHint("You must paste a valid URL.");
       return;
     }
     try {
       const deck = await cardListFromUrlApi.cardListFromUrlRetrieve({
         url: deckUrl,
       });
-      setDeckUrlHint('');
+      setDeckUrlHint("");
       const decklist = new Decklist(deck);
       setDecklist(decklist.mainListString());
       setCommanderList(decklist.commanderListString());
@@ -346,7 +379,7 @@ const FindMyCombos: React.FC = () => {
     }
   };
 
-  const urlQueryParam = queryParameterAsString(router.query.deckUrl) ?? '';
+  const urlQueryParam = queryParameterAsString(router.query.deckUrl) ?? "";
 
   useEffect(() => {
     if (router.query.deckUrl != undefined) {
@@ -355,7 +388,7 @@ const FindMyCombos: React.FC = () => {
   }, [router.query.deckUrl]);
 
   useEffect(() => {
-    if (deckUrl === urlQueryParam && urlQueryParam != '') {
+    if (deckUrl === urlQueryParam && urlQueryParam != "") {
       handleUrlInput();
     }
   }, [deckUrl, urlQueryParam]);
@@ -374,12 +407,12 @@ const FindMyCombos: React.FC = () => {
     const commandersNormalized = currentlyParsedDeck
       ? currentlyParsedDeck.deck.commanders
           .map((c) => normalizeStringInput(c.card))
-          .join('+')
+          .join("+")
           .trim()
-          .replace(/\s+/g, '_')
+          .replace(/\s+/g, "_")
           .substring(0, 50)
-      : '';
-    return `${commandersNormalized ? `${commandersNormalized}_` : ''}decklist_combos`;
+      : "";
+    return `${commandersNormalized ? `${commandersNormalized}_` : ""}decklist_combos`;
   };
 
   const handleExportCombosToText = () => {
@@ -388,7 +421,10 @@ const FindMyCombos: React.FC = () => {
     }
 
     const combosExport = CombosExportService.exportToText(results.included);
-    DownloadFileService.downloadTextFile(`${getNormalizedFileName()}.txt`, combosExport);
+    DownloadFileService.downloadTextFile(
+      `${getNormalizedFileName()}.txt`,
+      combosExport,
+    );
   };
 
   const handleExportCombosToCsv = () => {
@@ -397,7 +433,10 @@ const FindMyCombos: React.FC = () => {
     }
 
     const combosExport = CombosExportService.exportToCsv(results.included);
-    DownloadFileService.downloadTextFile(`${getNormalizedFileName()}.csv`, combosExport);
+    DownloadFileService.downloadTextFile(
+      `${getNormalizedFileName()}.csv`,
+      combosExport,
+    );
   };
 
   return (
@@ -413,7 +452,8 @@ const FindMyCombos: React.FC = () => {
           Uncover combos in your deck, and discover potential combos.
         </h2>
         <label htmlFor="decklist-input" className="sr-only">
-          Copy and paste your decklist into the text box to discover the combos in your deck.
+          Copy and paste your decklist into the text box to discover the combos
+          in your deck.
         </label>
         <section>
           <label>Commanders:</label>
@@ -456,8 +496,14 @@ const FindMyCombos: React.FC = () => {
                       id="parse-decklist-input"
                       className={`${styles.clearDecklistInput} button`}
                       onClick={() => {
-                        window.history.replaceState(null, '', '/find-my-combos/');
-                        parseDecklist(decklist, commanderList).then(analyzeDeck);
+                        window.history.replaceState(
+                          null,
+                          "",
+                          "/find-my-combos/",
+                        );
+                        parseDecklist(decklist, commanderList).then(
+                          analyzeDeck,
+                        );
                       }}
                     >
                       Find New Combos!
@@ -472,39 +518,45 @@ const FindMyCombos: React.FC = () => {
                     </button>
                   </div>
 
-                  {decklistErrors.length === 0 && results && results.included.length > 0 && (
-                    <>
-                      <Modal open={exportModalOpen} onClose={() => setExportModalOpen(false)} closeIcon={true}>
-                        <h2>Select a file format to export combos</h2>
-                        <div className="flex flex-row gap-y-2">
-                          <button
-                            id="download-combos-txt-btn"
-                            type="button"
-                            className={`${styles.exportCombosInput} button`}
-                            onClick={handleExportCombosToText}
-                          >
-                            TXT
-                          </button>
-                          <button
-                            id="download-combos-csv-btn"
-                            type="button"
-                            className={`${styles.exportCombosInput} button`}
-                            onClick={handleExportCombosToCsv}
-                          >
-                            CSV
-                          </button>
-                        </div>
-                      </Modal>
-                      <button
-                        id="download-combos-file-btn"
-                        type="button"
-                        className={`${styles.exportCombosInput} button`}
-                        onClick={() => setExportModalOpen(true)}
-                      >
-                        Export Combos To File
-                      </button>
-                    </>
-                  )}
+                  {decklistErrors.length === 0 &&
+                    results &&
+                    results.included.length > 0 && (
+                      <>
+                        <Modal
+                          open={exportModalOpen}
+                          onClose={() => setExportModalOpen(false)}
+                          closeIcon={true}
+                        >
+                          <h2>Select a file format to export combos</h2>
+                          <div className="flex flex-row gap-y-2">
+                            <button
+                              id="download-combos-txt-btn"
+                              type="button"
+                              className={`${styles.exportCombosInput} button`}
+                              onClick={handleExportCombosToText}
+                            >
+                              TXT
+                            </button>
+                            <button
+                              id="download-combos-csv-btn"
+                              type="button"
+                              className={`${styles.exportCombosInput} button`}
+                              onClick={handleExportCombosToCsv}
+                            >
+                              CSV
+                            </button>
+                          </div>
+                        </Modal>
+                        <button
+                          id="download-combos-file-btn"
+                          type="button"
+                          className={`${styles.exportCombosInput} button`}
+                          onClick={() => setExportModalOpen(true)}
+                        >
+                          Export Combos To File
+                        </button>
+                      </>
+                    )}
                 </div>
               )}
               {decklistErrors.map((error) => (
@@ -514,7 +566,11 @@ const FindMyCombos: React.FC = () => {
           )}
 
           {!decklist && (
-            <div id="decklist-hint" className={`${styles.decklistHint} heading-subtitle`} aria-hidden="true">
+            <div
+              id="decklist-hint"
+              className={`${styles.decklistHint} heading-subtitle`}
+              aria-hidden="true"
+            >
               Paste your decklist
             </div>
           )}
@@ -530,12 +586,16 @@ const FindMyCombos: React.FC = () => {
                 placeholder="Supported deckbuilding sites: Archidekt, Moxfield, Deckstats.net, TappedOut.net."
                 onChange={(e) => setDeckUrl(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
+                  if (e.key === "Enter") {
                     handleUrlInput();
                   }
                 }}
               />
-              <div id="decklist-url-hint" className={`${styles.decklistHint} heading-subtitle`} aria-hidden="true">
+              <div
+                id="decklist-url-hint"
+                className={`${styles.decklistHint} heading-subtitle`}
+                aria-hidden="true"
+              >
                 Paste your decklist url
               </div>
               {!!deckUrl && (
@@ -544,7 +604,7 @@ const FindMyCombos: React.FC = () => {
                   className={`${styles.clearDecklistInput} button`}
                   onClick={() =>
                     router.push({
-                      pathname: '/find-my-combos/',
+                      pathname: "/find-my-combos/",
                       query: { deckUrl },
                     })
                   }
@@ -574,18 +634,28 @@ const FindMyCombos: React.FC = () => {
           </div>
         </section>
         {currentlyParsedDeck &&
-          (format === 'commander' ? (
+          (format === "commander" ? (
             <Tab
               tabs={[
                 {
                   title: <>Combos&nbsp;{lookupInProgress && <Loader />}</>,
-                  content: <DeckCombos results={results} format={format} currentlyParsedDeck={currentlyParsedDeck} />,
+                  content: (
+                    <DeckCombos
+                      results={results}
+                      format={format}
+                      currentlyParsedDeck={currentlyParsedDeck}
+                    />
+                  ),
                 },
                 {
                   title: (
                     <>
                       Bracket Info&nbsp;
-                      {bracketInfo ? `(Est. ${BRACKET_RANGE_MAP[bracketInfo.bracketTag]})` : <Loader />}
+                      {bracketInfo ? (
+                        `(Est. ${BRACKET_RANGE_MAP[bracketInfo.bracketTag]})`
+                      ) : (
+                        <Loader />
+                      )}
                     </>
                   ),
                   content: <DeckBracket results={bracketInfo} />,
@@ -593,7 +663,11 @@ const FindMyCombos: React.FC = () => {
               ]}
             />
           ) : (
-            <DeckCombos results={results} format={format} currentlyParsedDeck={currentlyParsedDeck} />
+            <DeckCombos
+              results={results}
+              format={format}
+              currentlyParsedDeck={currentlyParsedDeck}
+            />
           ))}
       </div>
     </>


### PR DESCRIPTION
## Summary
- Adds a sessionStorage-backed cache (`src/lib/findMyCombosResultsCache.ts`) that persists deck-analysis results, format, bracket info, and scroll position on the Find My Combos page.
- Hydrates from cache on mount when the parsed deck matches the cached deck JSON, avoiding an unnecessary re-analysis on back-navigation. Cache invalidates automatically when the deck changes.
- Restores scroll position via `useLayoutEffect` keyed on `results` (with a `pendingScrollY` ref), which runs after the combo list commits to the DOM but before paint — replacing native `scrollRestoration` which wasn't working reliably.

Closes #867 

## Test plan
- [x] Load Find My Combos with a saved deck, scroll partway down the results, click into a combo detail page, then hit Back — should land at the same scroll position with the same results visible.
- [x] Change the deck from the textarea — old cache should be cleared and a fresh analyze should run.
- [x] Change the format dropdown after results load — should re-analyze (only when the format actually changes, not redundantly during cache hydration).
- [x] Hit the Clear button — cache should be wiped; navigating away and back should not restore prior results.
- [x] Confirm in private/incognito mode (sessionStorage may be restricted) — page still functions, just without persistence.